### PR TITLE
Use accurate benchmark for Koffi

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -16,6 +16,10 @@ const libm = ffi.Library('./libsum', {
   'sum': ['int', ['int', 'int']],
   concatenateStrings: ['string', ['string', 'string']],
 });
+const koffi_libm = {
+  sum: koffilib.func('int sum(int a, int b)'),
+  concatenateStrings: koffilib.func('const char *concatenateStrings(const char *str1, const char *str2)')
+};
 
 async function run() {
   await b.suite(
@@ -25,10 +29,8 @@ async function run() {
       libm.concatenateStrings("foo", "bar");
     }),
     b.add('koffi', () => {
-      const sum = koffilib.func('int sum(int a, int b)');
-      const concatenateStrings = koffilib.func('const char *concatenateStrings(const char *str1, const char *str2)');
-      sum(1, 2)
-      concatenateStrings("foo", "bar")
+      koffi_libm.sum(1, 2)
+      koffi_libm.concatenateStrings("foo", "bar")
     }),
     b.add('ffi-rs', () => {
       load({

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -12,7 +12,7 @@ open({
   library: 'libsum',
   path: dynamicLib
 })
-const libm = ffi.Library('libsum', {
+const libm = ffi.Library('./libsum', {
   'sum': ['int', ['int', 'int']],
   concatenateStrings: ['string', ['string', 'string']],
 });

--- a/cpp/sum.cpp
+++ b/cpp/sum.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <xlocale/_stdio.h>
 
 extern "C" int sum(int a, int b) { return a + b; }
 


### PR DESCRIPTION
Your benchmark code does not use Koffi correctly, because (like node-ffi) you are supposed to declare your functions ahead of time.

Not doing so results in a lot of memory usage (leak) and very slow code because Koffi computes a bunch of ABI-specific stuff when the function is declared, in order to make the calls faster. This is made even worst by the fact that you are using the prototype parser, which means on each iteration the function prototypes are parsed again and again for no reason.

This PR fixes that.

Before the fix (Koffi misuse):

```
Running "ffi" suite...
Progress: 100%

  ffi-napi:
    872 ops/s, ±2.99%       | slowest, 99.53% slower

  koffi:
    25 021 ops/s, ±13.08%    | 86.54% slower

  ffi-rs:
    185 829 ops/s, ±0.21%   | fastest

Finished 3 cases!
  Fastest: ffi-rs
  Slowest: ffi-napi
```

After the fix:

```
Running "ffi" suite...
Progress: 100%

  ffi-napi:
    856 ops/s, ±3.52%         | slowest, 99.93% slower

  koffi:
    1 159 188 ops/s, ±3.08%   | fastest

  ffi-rs:
    184 835 ops/s, ±0.24%     | 84.05% slower

Finished 3 cases!
  Fastest: koffi
  Slowest: ffi-napi
```

Please take this PR because as it-is you are severly misrepresenting the performance of Koffi.