### PR TITLE
docs: update README_Zh.md fix npm i ffi-rs error command

### DIFF
--- a/README_Zh.md
+++ b/README_Zh.md
@@ -60,7 +60,7 @@ Finished 2 cases!
 ## 安装
 
 ```js
-$ npm i ffi - rs
+$ npm i ffi-rs
 ```
 
 ## 支持的类型


### PR DESCRIPTION
docs have a error in README_Zh.md if you use npm i ffi - rs , this command is error npm cant find it , in this commit , i fixed it.
<img width="1119" height="352" alt="image" src="https://github.com/user-attachments/assets/87dad932-3aef-410a-a694-e18da0a9189e" />