### PR TITLE
feat: add zero-copy createExternalBuffer to wrap a native pointer as a Buffer

### DIFF
--- a/scripts/type.js
+++ b/scripts/type.js
@@ -305,7 +305,7 @@ if (!nativeBinding) {
     (processParamsTypeForArray(params))
 }
 
-const { DataType, createPointer, restorePointer, unwrapPointer, wrapPointer, freePointer, open, close, load, isNullPointer, FFITypeTag } = nativeBinding
+const { DataType, createPointer, restorePointer, unwrapPointer, wrapPointer, freePointer, open, close, load, isNullPointer, FFITypeTag, createExternalBuffer } = nativeBinding
 DataType.StackStruct = 999
 DataType.Function = 998
 DataType.Array = 997
@@ -358,6 +358,7 @@ exports.restorePointer = (params) => restorePointer(processParamsTypeForArray(pa
 exports.unwrapPointer = (params) => unwrapPointer(processParamsTypeForArray(params))
 exports.wrapPointer = (params) => wrapPointer(processParamsTypeForArray(params))
 exports.freePointer = (params) => freePointer(setFreePointerTag(processParamsTypeForArray(params)))
+exports.createExternalBuffer = createExternalBuffer
 exports.arrayConstructor = arrayConstructor
 
 exports.funcConstructor = (options) => ({

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -155,6 +155,25 @@ export function wrapPointer(params: JsExternal[]): JsExternal[]
 
 export function isNullPointer(params: JsExternal): boolean
 
+/**
+ * Wrap an existing native pointer into a Node.js `Buffer` **without copying**.
+ *
+ * The returned Buffer shares the same memory as `external`, so reads/writes on
+ * either side are immediately visible on the other — the zero-copy equivalent
+ * of ffi-napi's `ref.reinterpret`.
+ *
+ * `external` is the pointer to wrap (a `DataType.External` returned from `load`,
+ * or any `JsExternal` from `createPointer`/`unwrapPointer`/`wrapPointer`).
+ * `length` is the number of bytes to expose.
+ *
+ * ffi-rs does NOT free the underlying memory when the Buffer is garbage
+ * collected; the caller owns the pointer's lifetime (e.g. a region returned by
+ * `mmap` must stay mapped until you are done with the Buffer and call `munmap`
+ * yourself). On runtimes that forbid external buffers (e.g. Electron) this
+ * silently falls back to copying the data.
+ */
+export function createExternalBuffer(external: JsExternal, length: number): Buffer
+
 type ResultWithErrno<T, E = undefined> = E extends true
   ? { value: T; errnoCode: number; errnoMessage: string }
   : T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,46 @@ unsafe fn wrap_pointer(env: Env, params: Vec<JsExternal>) -> Result<Vec<JsExtern
     .collect()
 }
 
+/// Wrap an existing native pointer (a `DataType.External` returned from `load`,
+/// or any `JsExternal` from `createPointer`/`unwrapPointer`) into a Node.js
+/// `Buffer` **without copying**. The returned Buffer shares the same memory as
+/// the pointer, so reads/writes on either side are immediately visible on the
+/// other. This is the zero-copy equivalent of ffi-napi's `ref.reinterpret`.
+///
+/// `external` is the pointer to wrap and `length` is the number of bytes to
+/// expose. The caller is responsible for the lifetime of the underlying
+/// memory: ffi-rs does NOT free it when the Buffer is garbage-collected, so
+/// the pointer must stay valid for as long as the Buffer is used (e.g. the
+/// region returned by `mmap` must remain mapped until you are done with the
+/// Buffer and call `munmap` yourself).
+///
+/// On runtimes that forbid external buffers (e.g. Electron), this silently
+/// falls back to copying the data, so the Buffer is still usable but loses
+/// the zero-copy/shared-mutability property.
+#[napi]
+unsafe fn create_external_buffer(
+  env: Env,
+  external: JsExternal,
+  length: i64,
+) -> Result<JsUnknown> {
+  let ptr = get_js_external_wrap_data(&env, external)?;
+  let len = length as usize;
+  if ptr.is_null() {
+    return Err(napi::Error::from_reason(
+      "create_external_buffer: pointer is null",
+    ));
+  }
+  if len == 0 {
+    // A zero-length external buffer is not allowed; hand back an empty buffer.
+    return Ok(env.create_buffer(0)?.into_unknown());
+  }
+  // Borrow the native memory: a no-op finalizer means ffi-rs will never free
+  // it. The caller owns the memory (e.g. it came from mmap/malloc) and is
+  // responsible for keeping it valid while the Buffer is alive.
+  let buf = env.create_buffer_with_borrowed_data(ptr as *mut u8, len, (), |_, _| {})?;
+  Ok(buf.into_unknown())
+}
+
 #[napi]
 unsafe fn open(params: OpenParams) -> Result<()> {
   let OpenParams { library, path } = params;

--- a/tests/issue-139.ts
+++ b/tests/issue-139.ts
@@ -1,0 +1,222 @@
+import { equal, deepStrictEqual, ok } from "assert";
+import {
+  open,
+  close,
+  load,
+  DataType,
+  createPointer,
+  restorePointer,
+  unwrapPointer,
+  wrapPointer,
+  freePointer,
+  createExternalBuffer,
+  arrayConstructor,
+  PointerType,
+} from "../index";
+import { logGreen } from "./utils";
+
+// Access libc through the main-program handle (path: "").
+// libc provides malloc/free/memset/memcpy, which is all we need to demonstrate
+// zero-copy buffer wrapping without touching the bundled C++ test lib.
+open({ library: "libc", path: "" });
+
+const MALLOC = "malloc";
+const FREE = "free";
+const MEMSET = "memset";
+const MEMCPY = "memcpy";
+
+function ns(): number {
+  const t = process.hrtime.bigint();
+  return Number(t);
+}
+
+function alloc(size: number) {
+  const ptr = load({
+    library: "libc",
+    funcName: MALLOC,
+    retType: DataType.External,
+    paramsType: [DataType.U64],
+    paramsValue: [size],
+  }) as unknown as { _externalDataPlaceholder: unknown };
+  return ptr;
+}
+
+function freePtr(ptr: unknown) {
+  load({
+    library: "libc",
+    funcName: FREE,
+    retType: DataType.Void,
+    paramsType: [DataType.External],
+    paramsValue: [ptr],
+  });
+}
+
+function memset(ptr: unknown, value: number, size: number) {
+  load({
+    library: "libc",
+    funcName: MEMSET,
+    retType: DataType.External,
+    paramsType: [DataType.External, DataType.I32, DataType.U64],
+    paramsValue: [ptr, value, size],
+  });
+}
+
+function memcpy(dst: unknown, src: Buffer, size: number) {
+  load({
+    library: "libc",
+    funcName: MEMCPY,
+    retType: DataType.External,
+    paramsType: [DataType.External, DataType.U8Array, DataType.U64],
+    paramsValue: [dst, src, size],
+  });
+}
+
+function testZeroCopyRead() {
+  const size = 256;
+  const ptr = alloc(size);
+  ok(ptr, "malloc returned a non-null pointer");
+
+  const known = Buffer.alloc(size, 0);
+  for (let i = 0; i < size; i++) known[i] = (i * 7) & 0xff;
+  memset(ptr, 0, size);
+  memcpy(ptr, known, size);
+
+  // Zero-copy wrap: no data is copied, the Buffer aliases the malloc'd region.
+  const buf = createExternalBuffer(ptr, size);
+  equal(buf.length, size, "buffer length matches requested size");
+  deepStrictEqual(
+    Buffer.from(buf),
+    known,
+    "zero-copy read: buffer contents equal the bytes at the pointer"
+  );
+
+  freePtr(ptr);
+  logGreen("testZeroCopyRead passed");
+}
+
+function testSharedMutability() {
+  const size = 64;
+  const ptr = alloc(size);
+  memset(ptr, 0, size);
+
+  // Wrap the same memory once and mutate it through the Buffer.
+  const bufA = createExternalBuffer(ptr, size);
+  for (let i = 0; i < size; i++) bufA[i] = 0xa5 ^ (i & 0x1f);
+
+  // Wrap the SAME pointer again. Because the first wrap is zero-copy, the two
+  // Buffers must alias the same memory — a copy would have decoupled them.
+  const bufB = createExternalBuffer(ptr, size);
+  deepStrictEqual(
+    Buffer.from(bufB),
+    Buffer.from(bufA),
+    "shared memory: writes through one Buffer are visible through another wrap of the same pointer"
+  );
+
+  // Mutating the second Buffer must also be visible via a third wrap.
+  bufB[0] = 0x42;
+  const bufC = createExternalBuffer(ptr, size);
+  equal(bufC[0], 0x42, "shared memory: write through second wrap is visible to a third");
+
+  freePtr(ptr);
+  logGreen("testSharedMutability passed");
+}
+
+function testContrastWithRestorePointer() {
+  // restorePointer COPIES: mutating its Buffer must NOT affect the pointer.
+  const size = 32;
+  const ptr = alloc(size);
+  memset(ptr, 0x11, size);
+
+  const ptrWrap = wrapPointer([ptr]);
+  const restored = restorePointer({
+    retType: [arrayConstructor({ type: DataType.U8Array, length: size })],
+    paramsValue: ptrWrap,
+  }) as unknown as Buffer[];
+
+  equal(restored.length, 1);
+  equal(Buffer.from(restored[0]).every((b) => b === 0x11), true, "restore reads 0x11 fill");
+
+  // Mutate the copied buffer; the underlying memory must be untouched.
+  for (let i = 0; i < size; i++) restored[0][i] = 0xee;
+
+  const buf = createExternalBuffer(ptr, size);
+  equal(
+    Buffer.from(buf).every((b) => b === 0x11),
+    true,
+    "restorePointer copied: mutating its buffer does not affect the live pointer"
+  );
+
+  freePtr(ptr);
+  logGreen("testContrastWithRestorePointer passed");
+}
+
+function testBenchmarkVsRestorePointer() {
+  const size = 4096;
+  const ptr = alloc(size);
+  memset(ptr, 0x33, size);
+  const ptrWrap = wrapPointer([ptr]);
+  const desc = arrayConstructor({ type: DataType.U8Array, length: size });
+
+  const iters = 50_000;
+  // warm up
+  for (let i = 0; i < 1000; i++) createExternalBuffer(ptr, size);
+  for (let i = 0; i < 1000; i++)
+    restorePointer({ retType: [desc], paramsValue: ptrWrap });
+
+  const t0 = ns();
+  for (let i = 0; i < iters; i++) createExternalBuffer(ptr, size);
+  const wrapNs = ns() - t0;
+
+  const t1 = ns();
+  for (let i = 0; i < iters; i++)
+    restorePointer({ retType: [desc], paramsValue: ptrWrap });
+  const restoreNs = ns() - t1;
+
+  const wrapAvg = wrapNs / iters;
+  const restoreAvg = restoreNs / iters;
+
+  console.log(
+    `  createExternalBuffer avg: ${wrapAvg.toFixed(1)}ns/op | restorePointer avg: ${restoreAvg.toFixed(1)}ns/op | speedup ~${(restoreAvg / wrapAvg).toFixed(1)}x`
+  );
+  ok(
+    wrapAvg < restoreAvg,
+    "createExternalBuffer (zero-copy) is faster than restorePointer (copies)"
+  );
+
+  freePtr(ptr);
+  logGreen("testBenchmarkVsRestorePointer passed");
+}
+
+function testNullPointerRejected() {
+  // createPointer of a zero pointer yields a (null) external we can hand to
+  // createExternalBuffer to confirm null pointers are rejected, not silently
+  // wrapped.
+  let threw = false;
+  try {
+    const nullExt = createPointer({
+      paramsType: [DataType.External],
+      paramsValue: [0],
+    })[0];
+    createExternalBuffer(nullExt, 16);
+  } catch {
+    threw = true;
+  }
+  ok(threw, "a null pointer must be rejected, not wrapped into a Buffer");
+  logGreen("testNullPointerRejected passed");
+}
+
+async function main() {
+  testZeroCopyRead();
+  testSharedMutability();
+  testContrastWithRestorePointer();
+  testBenchmarkVsRestorePointer();
+  testNullPointerRejected();
+  close("libc");
+  logGreen("issue-139 test passed");
+}
+
+main().catch((err) => {
+  close("libc");
+  console.error("issue-139 test FAILED:", err && err.stack ? err.stack : err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #139

## Problem

ffi-rs has no way to get a zero-copy `Buffer` from a native pointer. `restorePointer` always copies: for `U8Array` it goes through `get_js_unknown_from_pointer` (`src/utils/dataprocess.rs`) which does

```rust
RefDataType::U8Array => {
  let arr = create_array_from_pointer(*(ptr as *mut *mut c_uchar), array_len); // pointer -> Vec<u8>
  rs_value_to_js_unknown(env, get_safe_buffer(env, arr, false))               // Vec<u8> -> Buffer
}
```

so it is slower than `fs.readSync` and ~2 orders of magnitude slower than ffi-napi's `ref.reinterpret`, which wraps the external memory with `Buffer.from(ptr, len)` and doesn't copy.

## Fix

Add a new `createExternalBuffer(external, length): Buffer` export that wraps an existing native pointer (a `DataType.External` returned from `load`, or any `JsExternal` from `createPointer`/`unwrapPointer`/`wrapPointer`) into a Node `Buffer` using `napi_create_external_buffer` — **zero copy**. The Buffer aliases the pointer's memory, so reads/writes on either side are immediately visible on the other. This is the zero-copy equivalent of ffi-napi's `ref.reinterpret`.

- ffi-rs does **not** free the underlying memory when the Buffer is GC'd (no-op finalizer). The caller owns the lifetime — e.g. an `mmap` region must stay mapped until the caller calls `munmap`, a `malloc`'d region must be `free`'d by the caller.
- On runtimes that forbid external buffers (e.g. Electron), `napi_create_external_buffer` returns `napi_no_external_buffers_allowed`; `create_buffer_with_borrowed_data` already handles this by falling back to a copy, so the Buffer stays usable (it just loses the shared-mutability property).

### mmap usage (matches the issue author's ffi-napi example)

```ts
import { open, load, close, DataType, createExternalBuffer } from "ffi-rs";

open({ library: "libc", path: "" });

const PROT_READ = 1, PROT_WRITE = 2, MAP_SHARED = 1;

const ptr = load({
  library: "libc",
  funcName: "mmap",
  retType: DataType.External,        // void* pointer
  paramsType: [DataType.I64, DataType.I64, DataType.I32, DataType.I32, DataType.I32, DataType.I64],
  paramsValue: [0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0],
});
if (!ptr) throw new Error("mmap failed");

// Zero-copy: sharedBuffer aliases the mmap'd region, no copy.
const sharedBuffer = createExternalBuffer(ptr, size);

// ... caller is responsible for munmap; ffi-rs won't free it
load({ library: "libc", funcName: "munmap", retType: DataType.I32,
  paramsType: [DataType.External, DataType.I64], paramsValue: [ptr, size] });
close("libc");
```

## Files

- `src/lib.rs` — new `#[napi] unsafe fn create_external_buffer(env, external, length) -> Result<JsUnknown>` using `env.create_buffer_with_borrowed_data`; rejects null pointers, returns an empty buffer for length 0.
- `scripts/type.js` — re-export `createExternalBuffer` from the native binding.
- `scripts/types.d.ts` — `export function createExternalBuffer(external: JsExternal, length: number): Buffer` with doc comments.
- `tests/issue-139.ts` — new test.

## Verification

`npx esno tests/issue-139.ts` on macOS arm64:

```
testZeroCopyRead passed              # Buffer contents == bytes at the pointer
testSharedMutability passed          # two wraps of the same pointer see each other's writes
testContrastWithRestorePointer passed # restorePointer copies (mutating its Buffer doesn't affect the live pointer); createExternalBuffer does not
  createExternalBuffer avg: 343.7ns/op | restorePointer avg: 1653.0ns/op | speedup ~4.8x
testNullPointerRejected passed
issue-139 test passed
```

`createExternalBuffer` is in the same ballpark as ffi-napi's ~411ns and far faster than the issue's reported `fs.readSync` 91011ns and `restorePointer` ~168000ns. Existing `issue-134` and `issue-135` tests still pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
